### PR TITLE
Fixing issue with Portal where data-dev was hardcoded

### DIFF
--- a/src/rspvalidator/config.py
+++ b/src/rspvalidator/config.py
@@ -61,6 +61,7 @@ urls = {
     "squareone": f"{BASE_URL}/",
     "tap": f"{BASE_URL}/api/tap",
     "ssotap": f"{BASE_URL}/api/ssotap",
+    "datalink": f"{BASE_URL}/api/datalink",
 }
 
 query_methods = {

--- a/src/rspvalidator/services/validation.py
+++ b/src/rspvalidator/services/validation.py
@@ -17,7 +17,7 @@ __all__ = [
     "TAPValidationService",
     "SquareOneValidationService",
     "TaplintValidationService",
-    "BaseValidationService"
+    "BaseValidationService",
 ]
 
 
@@ -197,4 +197,4 @@ class TaplintValidationService:
         ), f"TAPLINT reported {error_count} errors, which exceeds the limit of 92"
 
         logger.info("Full output:")
-        logger.info(output)
+        logger.info(self.output)

--- a/src/rspvalidator/tests/test_nublado.py
+++ b/src/rspvalidator/tests/test_nublado.py
@@ -184,6 +184,7 @@ def test_nublado_dp03_06_upload_tables(page: Page) -> None:
     ).not_to_contain_text("Error")
 
 
+@pytest.mark.skipif(SKIP_TESTS, reason="Skipping test as per config flag")
 def test_nublado_dp02_13a_image_cutout(page: Page) -> None:
     """Test the Nublado tutorial dp02 Image Cutout demo notebook."""
     # Go to Nublado page

--- a/src/rspvalidator/tests/test_portal.py
+++ b/src/rspvalidator/tests/test_portal.py
@@ -95,7 +95,7 @@ def test_query_dp02_obscore(page: Page) -> None:
 
     # Check Datalink exists
     expect(page.get_by_role("grid")).to_contain_text(
-        "https://data-dev.lsst.cloud/api/datalink/links?ID=butler",
+        f"{ConfigReaderService.get_url("datalink")}/links?ID=butler",
         timeout=120000,
     )
 


### PR DESCRIPTION
**Summary:**

Fixing issue with Portal where data-dev was hardcoded
Fix a couple of bugs and missing things:
- @pytest.mark.skipif(SKIP_TESTS, reason="Skipping test as per config flag") missing from Nublado
- Add missing self to output log in validation.py
- Add comma to __all__ in validation.py