### PR TITLE
Change double-quotes to single quotes for get datalink call

### DIFF
--- a/src/rspvalidator/tests/test_portal.py
+++ b/src/rspvalidator/tests/test_portal.py
@@ -95,7 +95,7 @@ def test_query_dp02_obscore(page: Page) -> None:
 
     # Check Datalink exists
     expect(page.get_by_role("grid")).to_contain_text(
-        f"{ConfigReaderService.get_url("datalink")}/links?ID=butler",
+        f"{ConfigReaderService.get_url('datalink')}/links?ID=butler",
         timeout=120000,
     )
 


### PR DESCRIPTION
Change double-quotes to single quotes for get datalink call