### PR TITLE
Fixed bug with incorrect error reporting in taplint test

### DIFF
--- a/src/rspvalidator/config.py
+++ b/src/rspvalidator/config.py
@@ -81,6 +81,6 @@ SCENARIOS = [
 ]
 
 taplint_maximums = {
-    "tap": {"errors": 92, "warnings": 2},
-    "ssotap": {"errors": 47, "warnings": 1},
+    "tap": {"errors": 87, "warnings": 690},
+    "ssotap": {"errors": 46, "warnings": 2},
 }

--- a/src/rspvalidator/services/validation.py
+++ b/src/rspvalidator/services/validation.py
@@ -174,27 +174,22 @@ class TaplintValidationService:
         self.validate_summary()
 
     def validate_summary(self) -> None:
-        """Validate an RSP Taplint run.
-
-        Parameters
-        ----------
-        output
-            The output of the Taplint run.
-
-        """
+        """Validate an RSP Taplint run."""
         error_count, warning_count = TaplintParserService.parse_summary(
             self.output
         )
 
         assert error_count is not None, "Failed to parse TAPLINT summary"
 
-        assert (
-            error_count <= self._max_errors
-        ), f"TAPLINT reported {error_count} errors, which exceeds the limit of 92"
+        assert error_count <= self._max_errors, (
+            f"TAPLINT reported {error_count} errors, which exceeds the limit "
+            f"of 92"
+        )
 
-        assert (
-            warning_count <= self._max_warnings
-        ), f"TAPLINT reported {error_count} errors, which exceeds the limit of 92"
+        assert warning_count <= self._max_warnings, (
+            f"TAPLINT reported {warning_count} warnings, which exceeds the "
+            f"limitf 92"
+        )
 
         logger.info("Full output:")
         logger.info(self.output)

--- a/src/rspvalidator/tests/test_portal.py
+++ b/src/rspvalidator/tests/test_portal.py
@@ -65,7 +65,7 @@ def test_query_dp03(page: Page) -> None:
     page.get_by_role("button", name="Search").click()
 
     # Check first row value
-    expect(page.get_by_role("grid")).to_contain_text("112.6117", timeout=120000)
+    expect(page.get_by_role("grid")).to_contain_text("112.6117", timeout=240000)
     expect(page.get_by_role("grid")).to_contain_text("60513", timeout=30000)
 
     # Check UWS job info


### PR DESCRIPTION
Fixed error/warning counts to match what should be expected from current version deployed (Warnings for TAP were incorrect, they were based on a version deployed on dev)
Increase timeout for portal query that takes more than a minute to complete
