### PR TITLE
Fixed timeout issues, updated expected taplint values

### DIFF
--- a/src/rspvalidator/config.py
+++ b/src/rspvalidator/config.py
@@ -17,7 +17,8 @@ HOSTNAME = os.getenv("HOSTNAME", "data-dev.lsst.cloud")
 BASE_URL = f"https://{HOSTNAME}"
 HEADLESS = os.getenv("HEADLESS", "False").lower() == "true"
 TOKEN = os.getenv("TOKEN", "")
-SKIP_TESTS = True
+SKIP_TESTS = False
+SELECTOR_TIMEOUT = 180000
 
 try:
     FileManagerService.check_auth_file()
@@ -78,6 +79,6 @@ SCENARIOS = [
 ]
 
 taplint_maximums = {
-    "tap": {"errors": 87, "warnings": 690},
-    "ssotap": {"errors": 46, "warnings": 2},
+    "tap": {"errors": 92, "warnings": 690},
+    "ssotap": {"errors": 47, "warnings": 2},
 }

--- a/src/rspvalidator/conftest.py
+++ b/src/rspvalidator/conftest.py
@@ -5,14 +5,17 @@ from typing import Any, Generator  # noqa: UP035
 
 import pytest
 import pyvo
-from playwright.sync_api import sync_playwright
+from playwright.sync_api import expect, sync_playwright
 
-from .config import HEADLESS, TOKEN
+from .config import HEADLESS, SELECTOR_TIMEOUT, TOKEN
 from .constants import STILTS_FILENAME, STILTS_URL
 from .factories.tap_factory import TAPFactory
 from .services.configreader import ConfigReaderService
 from .services.filemanager import FileManagerService
 from .services.validation import TAPValidationService
+
+# Set default timeout for playwright
+expect.set_options(timeout=SELECTOR_TIMEOUT)
 
 
 @pytest.fixture(scope="session")
@@ -121,6 +124,7 @@ def page(browser: Any) -> Generator:
     """
     home_auth_path = Path("~/auth.json").expanduser()
     context = browser.new_context(storage_state=home_auth_path)
+    context.set_default_timeout(SELECTOR_TIMEOUT)
 
     # To add a bearer token: context.set_extra_http_headers({"Authorization":
     # f"Bearer {TOKEN}"}) (This doesn't seem to work atm)
@@ -228,7 +232,7 @@ def tap_validation_service_tap(
 
 
 @pytest.fixture(scope="module")
-def stilts_jar() -> Generator:
+def stilts_jar() -> Path:
     """
     Fixture to download the STILTS JAR file.
 

--- a/src/rspvalidator/tests/test_nublado.py
+++ b/src/rspvalidator/tests/test_nublado.py
@@ -19,7 +19,7 @@ def test_restart_kernels(page: Page) -> None:
     #  if we get the image selection choose default
     # Go to Nublado homepage
     page.goto(ConfigReaderService.get_url("nublado"))
-    page.get_by_text("Kernel", exact=True).click(timeout=100000)
+    page.get_by_text("Kernel", exact=True).click()
     page.locator("#jp-mainmenu-kernel").get_by_text("Shut Down All Kernels…").click()
     page.get_by_role("button", name="Shut Down All").click()
 
@@ -28,11 +28,11 @@ def test_restart_kernels(page: Page) -> None:
 def test_nublado_dp02_02b_catalog_access(page: Page) -> None:
     """Test the Nublado tutorial dp02 catalog access notebook."""
     # Go to Nublado homepage
-    page.goto(ConfigReaderService.get_url("nublado"), timeout=90000)
+    page.goto(ConfigReaderService.get_url("nublado"))
 
     # Go to main directory
     locator = page.locator("[title^='/home/']").first
-    locator.locator("path").dblclick(timeout=60000)
+    locator.locator("path").dblclick()
     page.get_by_text("File", exact=True).click()
     page.locator("#jp-mainmenu-file").get_by_text("Open from Path…").click()
     page.get_by_placeholder("/path/relative/to/jlab/root").fill(
@@ -45,7 +45,7 @@ def test_nublado_dp02_02b_catalog_access(page: Page) -> None:
         page.get_by_text(
             "Description: Execute complex ADQL queries with the TAP service."
         )
-    ).to_be_visible(timeout=1000000)
+    ).to_be_visible()
 
     # This is a hack, need to figure out why run is started before things
     # are loaded
@@ -60,19 +60,20 @@ def test_nublado_dp02_02b_catalog_access(page: Page) -> None:
         page.get_by_label("DP02_02b_Catalog_Queries_with_TAP.ipynb").get_by_label(
             "Cells", exact=True
         )
-    ).to_contain_text("173 rows", timeout=1000000)
+    ).to_contain_text("173 rows")
+
     expect(
         page.get_by_label("DP02_02b_Catalog_Queries_with_TAP.ipynb").get_by_label(
             "Cells", exact=True
         )
-    ).to_contain_text("1651589610221899038", timeout=1000000)
+    ).to_contain_text("1651589610221899038")
 
     # Check that there are no errors
     expect(
         page.get_by_label("DP02_02b_Catalog_Queries_with_TAP.ipynb").get_by_label(
             "Cells", exact=True
         )
-    ).not_to_contain_text("Traceback", timeout=1000000)
+    ).not_to_contain_text("Traceback")
     expect(
         page.get_by_label("DP02_02b_Catalog_Queries_with_TAP.ipynb").get_by_label(
             "Cells", exact=True
@@ -88,11 +89,12 @@ def test_nublado_dp02_06b_interactive_visualization(page: Page) -> None:
 
     # Open Notebook
     home_dir = page.locator("[title^='/home/']").first
-    home_dir.locator("path").dblclick(timeout=60000)
+    home_dir.locator("path").dblclick()
     page.get_by_text("File", exact=True).click()
     page.locator("#jp-mainmenu-file").get_by_text("Open from Path…").click()
     page.get_by_placeholder("/path/relative/to/jlab/root").fill(
-        "/notebooks/tutorial-notebooks/DP02_06b_Interactive_Catalog_Visualization.ipynb"
+        "/notebooks/tutorial-notebooks/"
+        "DP02_06b_Interactive_Catalog_Visualization.ipynb"
     )
     page.get_by_placeholder("/path/relative/to/jlab/root").press("Enter")
 
@@ -112,13 +114,13 @@ def test_nublado_dp02_06b_interactive_visualization(page: Page) -> None:
         page.get_by_label(
             "DP02_06b_Interactive_Catalog_Visualization.ipynb"
         ).get_by_label("Cells", exact=True)
-    ).to_contain_text("BokehJS 3.4.2 successfully loaded.", timeout=1000000)
+    ).to_contain_text("BokehJS 3.4.2 successfully loaded.")
 
     expect(
         page.get_by_label(
             "DP02_06b_Interactive_Catalog_Visualization.ipynb"
         ).get_by_label("Cells", exact=True)
-    ).to_contain_text("26914", timeout=1000000)
+    ).to_contain_text("26914")
 
     # Check that there are no errors
     expect(
@@ -141,7 +143,7 @@ def test_nublado_dp03_06_upload_tables(page: Page) -> None:
 
     # Open Notebook
     home_dir = page.locator("[title^='/home/']").first
-    home_dir.locator("path").dblclick(timeout=60000)
+    home_dir.locator("path").dblclick()
     page.get_by_text("File", exact=True).click()
     page.locator("#jp-mainmenu-file").get_by_text("Open from Path…").click()
     page.get_by_placeholder("/path/relative/to/jlab/root").fill(
@@ -150,14 +152,14 @@ def test_nublado_dp03_06_upload_tables(page: Page) -> None:
     page.get_by_placeholder("/path/relative/to/jlab/root").press("Enter")
 
     # Ensures that tab is loaded before running
-    page.get_by_text("Description: Use the TAP").click(timeout=1000000)
+    page.get_by_text("Description: Use the TAP").click()
 
     # This is a hack, need to figure out why run is started before things
     # are loaded
     time.sleep(5)
 
     # Run notebook
-    page.get_by_text("Run", exact=True).click(timeout=1000000)
+    page.get_by_text("Run", exact=True).click()
     page.locator("#jp-mainmenu-run").get_by_text("Run All Cells", exact=True).click()
 
     # Validate some of the expected output
@@ -165,22 +167,22 @@ def test_nublado_dp03_06_upload_tables(page: Page) -> None:
         page.get_by_label("DP03_06_User_Uploaded_Tables.ipynb").get_by_label(
             "Cells", exact=True
         )
-    ).to_contain_text("Table length=15", timeout=1000000)
+    ).to_contain_text("Table length=15")
     expect(
         page.get_by_label("DP03_06_User_Uploaded_Tables.ipynb").get_by_label(
             "Cells", exact=True
         )
-    ).to_contain_text("Job phase is COMPLETED", timeout=1000000)
+    ).to_contain_text("Job phase is COMPLETED")
     expect(
         page.get_by_label("DP03_06_User_Uploaded_Tables.ipynb").get_by_label(
             "Cells", exact=True
         )
-    ).to_contain_text("Table length=672", timeout=1000000)
+    ).to_contain_text("Table length=672")
     expect(
         page.get_by_label("DP03_06_User_Uploaded_Tables.ipynb").get_by_label(
             "Cells", exact=True
         )
-    ).to_contain_text("4350915375550808373", timeout=1000000)
+    ).to_contain_text("4350915375550808373")
 
     # Check that there are no errors
     expect(
@@ -203,7 +205,7 @@ def test_nublado_dp02_13a_image_cutout(page: Page) -> None:
 
     # Open Notebook
     home_dir = page.locator("[title^='/home/']").first
-    home_dir.locator("path").dblclick(timeout=60000)
+    home_dir.locator("path").dblclick()
     page.get_by_text("File", exact=True).click()
     page.locator("#jp-mainmenu-file").get_by_text("Open from Path…").click()
     page.get_by_placeholder("/path/relative/to/jlab/root").fill(
@@ -228,26 +230,26 @@ def test_nublado_dp02_13a_image_cutout(page: Page) -> None:
         page.get_by_label("DP02_13a_Image_Cutout_SciDemo.ipynb").get_by_label(
             "Cells", exact=True
         )
-    ).to_contain_text(f"{BASE_URL}/api/datalink/links?", timeout=1000000)
+    ).to_contain_text(f"{BASE_URL}/api/datalink/links?")
     expect(
         page.get_by_label("DP02_13a_Image_Cutout_SciDemo.ipynb").get_by_label(
             "Cells", exact=True
         )
-    ).to_contain_text("Table length=162452", timeout=1000000)
+    ).to_contain_text("Table length=162452")
     expect(
         page.get_by_label("DP02_13a_Image_Cutout_SciDemo.ipynb").get_by_label(
             "Cells", exact=True
         )
-    ).to_contain_text("Table length=1", timeout=1000000)
+    ).to_contain_text("Table length=1")
 
     # Check that there are no errors
     expect(
         page.get_by_label("DP02_13a_Image_Cutout_SciDemo.ipynb").get_by_label(
             "Cells", exact=True
         )
-    ).not_to_contain_text("Traceback", timeout=1000000)
+    ).not_to_contain_text("Traceback")
     expect(
         page.get_by_label("DP02_13a_Image_Cutout_SciDemo.ipynb").get_by_label(
             "Cells", exact=True
         )
-    ).not_to_contain_text("Error", timeout=1000000)
+    ).not_to_contain_text("Error")

--- a/src/rspvalidator/tests/test_portal.py
+++ b/src/rspvalidator/tests/test_portal.py
@@ -27,11 +27,11 @@ def test_query_dp02(page: Page) -> None:
     page.get_by_role("button", name="Search").click()
 
     # Validate results
-    expect(page.get_by_role("grid")).to_contain_text("48.5080681", timeout=360000)
+    expect(page.get_by_role("grid")).to_contain_text("48.5080681")
 
     # Check UWS job info
     page.get_by_role("button", name="Show additional table info").click()
-    expect(page.locator("#dialogRootDiv")).to_contain_text("COMPLETED", timeout=60000)
+    expect(page.locator("#dialogRootDiv")).to_contain_text("COMPLETED")
 
 
 def test_query_dp03(page: Page) -> None:
@@ -46,19 +46,19 @@ def test_query_dp03(page: Page) -> None:
     ).first.click()
     page.get_by_role("button", name="Edit ADQL", exact=True).click()
     page.locator("#adqlEditor").fill(
-        "SELECT TOP 1000 * FROM dp03_catalogs_10yr.SSObject ORDER BY " "ssObjectId"
+        "SELECT TOP 1000 * FROM dp03_catalogs_10yr.SSObject " "ORDER BY ssObjectId"
     )
 
     # Run query
     page.get_by_role("button", name="Search").click()
 
     # Check first row value
-    expect(page.get_by_role("grid")).to_contain_text("112.6117", timeout=240000)
-    expect(page.get_by_role("grid")).to_contain_text("60513", timeout=30000)
+    expect(page.get_by_role("grid")).to_contain_text("112.6117")
+    expect(page.get_by_role("grid")).to_contain_text("60513")
 
     # Check UWS job info
     page.get_by_role("button", name="Show additional table info").click()
-    expect(page.locator("#dialogRootDiv")).to_contain_text("COMPLETED", timeout=60000)
+    expect(page.locator("#dialogRootDiv")).to_contain_text("COMPLETED")
 
 
 def test_query_dp02_obscore(page: Page) -> None:
@@ -81,10 +81,9 @@ def test_query_dp02_obscore(page: Page) -> None:
 
     # Check Datalink exists
     expect(page.get_by_role("grid")).to_contain_text(
-        f"{ConfigReaderService.get_url('datalink')}/links?ID=butler",
-        timeout=120000,
+        f"{ConfigReaderService.get_url('datalink')}/links?ID=butler"
     )
 
     # Check UWS job info
     page.get_by_role("button", name="Show additional table info").click()
-    expect(page.locator("#dialogRootDiv")).to_contain_text("COMPLETED", timeout=60000)
+    expect(page.locator("#dialogRootDiv")).to_contain_text("COMPLETED")


### PR DESCRIPTION
- Updated some of the expected test outputs
- Created global timeout for expects
- Enable nublado tests again
- Update expected taplint error & warning count