### PR TITLE
Enable TOKEN passenv in tox.ini

### DIFF
--- a/src/rspvalidator/config.py
+++ b/src/rspvalidator/config.py
@@ -19,6 +19,7 @@ HEADLESS = os.getenv("HEADLESS", "False").lower() == "true"
 TOKEN = os.getenv("TOKEN", "")
 SKIP_TESTS = False
 SELECTOR_TIMEOUT = 180000
+TRACING = False
 
 try:
     FileManagerService.check_auth_file()

--- a/src/rspvalidator/tests/test_portal.py
+++ b/src/rspvalidator/tests/test_portal.py
@@ -53,7 +53,7 @@ def test_query_dp03(page: Page) -> None:
     page.get_by_role("button", name="Search").click()
 
     # Check first row value
-    expect(page.get_by_role("grid")).to_contain_text("112.6117")
+    expect(page.get_by_role("grid")).to_contain_text("I dont know", timeout=30000)
     expect(page.get_by_role("grid")).to_contain_text("60513")
 
     # Check UWS job info

--- a/src/rspvalidator/tests/test_portal.py
+++ b/src/rspvalidator/tests/test_portal.py
@@ -53,7 +53,7 @@ def test_query_dp03(page: Page) -> None:
     page.get_by_role("button", name="Search").click()
 
     # Check first row value
-    expect(page.get_by_role("grid")).to_contain_text("I dont know", timeout=30000)
+    expect(page.get_by_role("grid")).to_contain_text("112.6117")
     expect(page.get_by_role("grid")).to_contain_text("60513")
 
     # Check UWS job info

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ commands =
     pytest -vv
 setenv =
     HEADLESS = True
+passenv = TOKEN
 
 [testenv:typing]
 description = Run mypy.


### PR DESCRIPTION
- Pass in the user's TOKEN env when running via tox
- Enable playwright Tracing option